### PR TITLE
Automated PyInstaller release workflow

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,79 @@
+name: Build and Release
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+    types: [closed]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyinstaller -r requirements.txt
+
+      - name: Build executable
+        run: pyinstaller --noconfirm --onefile src/gui.py
+
+      - name: Rename binary
+        shell: bash
+        run: |
+          EXT=""
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            EXT=".exe"
+          fi
+          mv dist/gui${EXT} Comparador-${RUNNER_OS}${EXT}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: Comparador-${{ runner.os }}
+          path: Comparador-${{ runner.os }}*
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' || github.event.pull_request.merged == true
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: artifacts
+
+      - name: Determine next version
+        id: version
+        run: |
+          git fetch --tags
+          last=$(git tag -l 'v*' | sort -V | tail -n1)
+          if [ -z "$last" ]; then
+            ver="0.1"
+          else
+            num=${last#v0.}
+            num=$((num + 1))
+            ver="0.$num"
+          fi
+          echo "version=$ver" >> "$GITHUB_OUTPUT"
+
+      - name: Create release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: v${{ steps.version.outputs.version }}
+          name: v${{ steps.version.outputs.version }}
+          artifacts: artifacts/**
+          body: |
+            Release automatically generated for version v${{ steps.version.outputs.version }}.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build Windows, Linux and macOS binaries using PyInstaller
- automatically create a release with incremented version numbers and attach artifacts

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6865c5b41d6883268f1ec86fd394cc37