### PR TITLE
Allow separator selection by format

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ Instalação típica leva menos de 1 minuto.
 Se o seu CSV real divergir, basta selecionar as letras corretas nos comboboxes antes de comparar.
 Caso os nomes das colunas sejam simples (sem prefixos ou sufixos do OpenRecLink),
 desmarque a opção **Formato OpenRecLink** na janela principal antes de abrir o arquivo.
+Quando o formato geral está ativo, o separador de colunas usado é a vírgula
+(`,`); no modo OpenRecLink, permanece o pipe (`|`).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -10,14 +10,13 @@ Originalmente escrita em Java, a lógica foi portada para Python, adicionando:
 
 * **GUI** em Tkinter com barra de progresso em tempo real
 * **Gerador de amostras sintéticas** (com typos/ruído)
-* Estatísticas resumidas pós‑processamento
 * Geração automática (e cache) das **tabelas de frequência** para bases grandes
 
 > 🗂 **Estrutura do repositório**
 >
 > ```text
 > src/
-> ├─ gui.py                # Interface Tk + progresso + estatísticas
+> ├─ gui.py                # Interface Tk com barra de progresso
 > ├─ comparaRegistros.py   # Núcleo de pontuação
 > ├─ util.py               # Soundex, padronização, Levenshtein…
 > ├─ freqbuilder.py        # Constrói tabelas de frequência on‑the‑fly
@@ -101,7 +100,6 @@ Instalação típica leva menos de 1 minuto.
    A barra mostrará o progresso.
 2. **Comparar**  → após escolher/generar o CSV, clique **Comparar**.
    Surgirá uma janela de progresso indeterminado; ao concluir, `saida.csv` (e `saida2.csv`) são criados.
-3. **Ver Estatísticas**  → clique *Estatísticas* para ver média, desvio‑padrão, etc.
 
 ### 3.2 Mapeamento de colunas
 

--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ Instalação típica leva menos de 1 minuto.
 Se o seu CSV real divergir, basta selecionar as letras corretas nos comboboxes antes de comparar.
 Caso os nomes das colunas sejam simples (sem prefixos ou sufixos do OpenRecLink),
 desmarque a opção **Formato OpenRecLink** na janela principal antes de abrir o arquivo.
-Quando o formato geral está ativo, o separador de colunas usado é a vírgula
-(`,`); no modo OpenRecLink, permanece o pipe (`|`).
+O separador padrão no formato geral é a vírgula (`,`); no modo OpenRecLink,
+é o pipe (`|`).  Se preferir, altere o caractere no campo **Separador**.
 
 ---
 

--- a/src/comparaRegistros.py
+++ b/src/comparaRegistros.py
@@ -280,13 +280,16 @@ def processar_generico(
     arquivo_entrada: str,
     arquivo_saida: str,
     pares: list[tuple[int, int, str, str]],
+    *,
+    sep: str = "|",
 ) -> None:
     """Processa genericamente pares de colunas.
 
     ``pares`` contém ``(idx1, idx2, tipo, nome)`` onde ``tipo`` é ``"C"`` para
     strings ou ``"D"`` para datas e ``nome`` é um rótulo para os campos.
+    O delimitador das colunas é definido por ``sep`` (padrão ``"|"``).
     """
-    df = pd.read_csv(arquivo_entrada, sep="|", dtype=str).fillna("")
+    df = pd.read_csv(arquivo_entrada, sep=sep, dtype=str).fillna("")
 
     freq_maps: dict[int, dict[str, int]] = {}
     for i, (idx1, idx2, tipo, _) in enumerate(pares):

--- a/src/gerador_amostra.py
+++ b/src/gerador_amostra.py
@@ -125,7 +125,8 @@ def generate_sample(
     """Gera ``n`` linhas de dados sintéticos em ``out_path``.
 
     O número de colunas é aleatório (30‑100) e os nomes seguem o formato
-    ``[C|R]_VAR,C|D,numero,outro``. O separador padrão é ``|``.
+    ``[C|R]_VAR,C|D,numero,outro``. O separador padrão é ``|``,
+    mas pode ser alterado pelo parâmetro ``sep``.
     """
 
     n_cols = random.randint(30, 100)

--- a/src/gui.py
+++ b/src/gui.py
@@ -146,11 +146,22 @@ class App(tk.Tk):
         self.label_to_right: dict[str, str] = {}
         self.boxes: list[dict[str, any]] = []
         self.openreclink_format = tk.BooleanVar(value=True)
+        self.sep_var = tk.StringVar()
+        self._set_default_sep()
         self._build()
 
+    def _set_default_sep(self) -> None:
+        """Atualiza ``sep_var`` conforme o formato escolhido."""
+        self.sep_var.set("|" if self.openreclink_format.get() else ",")
+
+    def _on_format_toggle(self) -> None:
+        """Callback para alternar o formato e atualizar o separador."""
+        self._set_default_sep()
+        self._load_header()
+
     def _sep(self) -> str:
-        """Return the column separator based on the selected format."""
-        return "|" if self.openreclink_format.get() else ","
+        """Return the column separator chosen by the user."""
+        return self.sep_var.get()
 
     def _build_fields(self):
         ttk.Label(self.frm_campos, text="Referência").grid(row=0, column=1, padx=5)
@@ -286,10 +297,14 @@ class App(tk.Tk):
             self,
             text="Formato OpenRecLink",
             variable=self.openreclink_format,
-            command=self._load_header,
+            command=self._on_format_toggle,
         )
         chk.place(x=650, y=210)
         ToolTip(chk, "Desmarque para cabeçalho simples")
+
+        ttk.Label(self, text="Separador:").place(x=650, y=240)
+        self.e_sep = ttk.Entry(self, textvariable=self.sep_var, width=5)
+        self.e_sep.place(x=730, y=237)
 
         # arquivo entrada / saída
         ttk.Label(self, text="Arquivo de entrada:").place(x=10, y=250)
@@ -350,6 +365,7 @@ class App(tk.Tk):
         self.boxes.clear()
         self._build_fields()
         self._load_header()
+        self._set_default_sep()
 
     def _show_help(self):
         help_win = tk.Toplevel(self)

--- a/src/gui.py
+++ b/src/gui.py
@@ -148,6 +148,10 @@ class App(tk.Tk):
         self.openreclink_format = tk.BooleanVar(value=True)
         self._build()
 
+    def _sep(self) -> str:
+        """Return the column separator based on the selected format."""
+        return "|" if self.openreclink_format.get() else ","
+
     def _build_fields(self):
         ttk.Label(self.frm_campos, text="Referência").grid(row=0, column=1, padx=5)
         ttk.Label(self.frm_campos, text="Comparação").grid(row=0, column=2, padx=5)
@@ -189,7 +193,7 @@ class App(tk.Tk):
         if not self.filepath:
             return
         try:
-            df = pd.read_csv(self.filepath, sep='|', nrows=0)
+            df = pd.read_csv(self.filepath, sep=self._sep(), nrows=0)
         except Exception as exc:
             messagebox.showerror('Erro', f'Falha ao ler CSV:\n{exc}')
             return
@@ -383,7 +387,12 @@ class App(tk.Tk):
         dlg = ProgressDialog(self, "Gerando amostra")
         def worker():
             try:
-                generate_sample(n, Path(dest), progress_cb=lambda p: dlg.put(p))
+                generate_sample(
+                    n,
+                    Path(dest),
+                    sep=self._sep(),
+                    progress_cb=lambda p: dlg.put(p),
+                )
                 dlg.put(100, "Concluído")
                 self.filepath = dest
                 self.e_in.delete(0, tk.END)
@@ -421,7 +430,12 @@ class App(tk.Tk):
         dlg.put(-1, "Processando…")
         def worker():
             try:
-                cr.processar_generico(self.filepath, out_base, pares)
+                cr.processar_generico(
+                    self.filepath,
+                    out_base,
+                    pares,
+                    sep=self._sep(),
+                )
                 self.output_csv = f"{out_base}.csv"
                 dlg.put(100, "Concluído")
                 messagebox.showinfo("Pronto", "Comparação concluída.")

--- a/src/gui.py
+++ b/src/gui.py
@@ -284,9 +284,9 @@ class App(tk.Tk):
         chk.place(x=650, y=210)
         ToolTip(chk, "Desmarque para cabeçalho simples")
 
-        ttk.Label(self, text="Delimitador:").place(x=640, y=240)
+        ttk.Label(self, text="Delimitador:").place(x=640, y=140)
         self.e_sep = ttk.Entry(self, textvariable=self.sep_var, width=6)
-        self.e_sep.place(x=740, y=237)
+        self.e_sep.place(x=740, y=137)
 
         # arquivo entrada / saída
         ttk.Label(self, text="Arquivo de entrada:").place(x=10, y=250)


### PR DESCRIPTION
## Summary
- support choosing column separator based on the selected format
- propagate separator to sample generation and processing
- document that general format uses comma separator

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6876bc18656c8326a105b009622e182d