### PR TITLE
Fix widget deletion bug

### DIFF
--- a/src/gui.py
+++ b/src/gui.py
@@ -202,12 +202,14 @@ class App(tk.Tk):
         widgets["lbl"].destroy()
         widgets["cb1"].destroy()
         widgets["cb2"].destroy()
+        widgets["frm_tipo"].destroy()
         widgets["btn"].destroy()
         self.boxes.remove(widgets)
         for i, w in enumerate(self.boxes, start=1):
             w["lbl"].config(text=f"Variável {i}:")
             for widget in w.values():
-                widget.grid_configure(row=i)
+                if hasattr(widget, "grid_configure"):
+                    widget.grid_configure(row=i)
         self._update_tipo_widgets()
 
     def _load_header(self):


### PR DESCRIPTION
## Summary
- fix leftover radio buttons when removing a row
- guard `grid_configure` calls for non-widget values

## Testing
- `python -m pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687900aa7e2c83269432b3dfedbd1fff